### PR TITLE
Add missing dependency to install instructions for PocketSphinx

### DIFF
--- a/documentation/installation/index.md
+++ b/documentation/installation/index.md
@@ -243,7 +243,7 @@ On Debian, you can install these from the `experimental` repository:
 {% highlight bash %}
 sudo su -c "echo 'deb http://ftp.debian.org/debian experimental main contrib non-free' > /etc/apt/sources.list.d/experimental.list"
 sudo apt-get update
-sudo apt-get -t experimental install phonetisaurus m2m-aligner mitlm
+sudo apt-get -t experimental install phonetisaurus m2m-aligner mitlm libfst-tools
 {% endhighlight %}
 
 If you're not using Debian, perform these steps:


### PR DESCRIPTION
Relates to https://github.com/jasperproject/jasperproject.github.io/issues/41

The current docs never mention `libfst-tools`, so the following step errors:

```bash
pi@raspberrypi2 ~/g014b2b $ sh compile-fst.sh 
fstcompile --ssymbols=g014b2b.ssyms --isymbols=g014b2b.isyms --keep_isymbols --osymbols=g014b2b.osyms --keep_osymbols g014b2b.fst.txt > g014b2b.fst
compile-fst.sh: 8: compile-fst.sh: fstcompile: not found
```